### PR TITLE
Fix/#146

### DIFF
--- a/Replicated_Storage_Service/src/app_kvClient/KVClient.java
+++ b/Replicated_Storage_Service/src/app_kvClient/KVClient.java
@@ -10,6 +10,7 @@ import weloveclouds.client.models.commands.CommandFactory;
 import weloveclouds.client.utils.CustomStringJoiner;
 import weloveclouds.communication.CommunicationApiFactory;
 import weloveclouds.server.api.v2.IKVCommunicationApiV2;
+import weloveclouds.server.models.conf.KVServerPortConstants;
 import weloveclouds.communication.models.ServerConnectionInfo;
 import weloveclouds.kvstore.deserialization.helper.RingMetadataDeserializer;
 import weloveclouds.server.utils.LogSetup;
@@ -20,6 +21,10 @@ import weloveclouds.server.utils.LogSetup;
  * @author Benoit, Benedek, Hunton
  */
 public class KVClient {
+
+    private static final String DEFAULT_LOG_PATH = "logs/client.log";
+    private static final String DEFAULT_LOG_LEVEL = "OFF";
+
     private static final Logger LOGGER = Logger.getLogger(KVClient.class);
 
     /**
@@ -28,12 +33,12 @@ public class KVClient {
      * @param args is discarded so far
      */
     public static void main(String[] args) {
-        String logFile = "logs/client.log";
-        try {
-            new LogSetup(logFile, Level.OFF);
+        initializeLoggerWithLevel(DEFAULT_LOG_LEVEL);
 
+        try {
             ServerConnectionInfo bootstrapConnectionInfo =
-                    new ServerConnectionInfo.Builder().ipAddress("localhost").port(8080).build();
+                    new ServerConnectionInfo.Builder().ipAddress("localhost")
+                            .port(KVServerPortConstants.KVCLIENT_REQUESTS_PORT).build();
             IKVCommunicationApiV2 serverCommunication = new CommunicationApiFactory()
                     .createKVCommunicationApiV2(bootstrapConnectionInfo);
 
@@ -50,8 +55,26 @@ public class KVClient {
             Client client = new Client(System.in, commandFactory);
             client.run();
         } catch (IOException ex) {
+            LOGGER.error("Unable to resolve default, bootstrap server IP address.");
+        }
+    }
+
+    /**
+     * Initializes the root logger with the referred logLevel.
+     */
+    private static void initializeLoggerWithLevel(String logLevel) {
+        initializeLoggerWithLevel(Level.toLevel(logLevel));
+    }
+
+    /**
+     * Initializes the root logger with the referred logLevel.
+     */
+    private static void initializeLoggerWithLevel(Level logLevel) {
+        try {
+            new LogSetup(DEFAULT_LOG_PATH, logLevel);
+        } catch (IOException ex) {
             System.err.println(CustomStringJoiner.join(" ", "Log file cannot be created on path ",
-                    logFile, "due to an error:", ex.getMessage()));
+                    DEFAULT_LOG_PATH, "due to an error:", ex.getMessage()));
         }
     }
 

--- a/Replicated_Storage_Service/src/app_kvServer/KVServer.java
+++ b/Replicated_Storage_Service/src/app_kvServer/KVServer.java
@@ -9,19 +9,11 @@ import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
 import weloveclouds.client.utils.CustomStringJoiner;
-import weloveclouds.ecs.core.ExternalConfigurationServiceConstants;
-import weloveclouds.kvstore.models.messages.KVAdminMessage;
-import weloveclouds.kvstore.models.messages.KVMessage;
-import weloveclouds.kvstore.models.messages.KVTransferMessage;
-import weloveclouds.server.core.Server;
 import weloveclouds.server.core.ServerCLIHandler;
 import weloveclouds.server.core.ServerFactory;
 import weloveclouds.server.models.commands.ServerCommandFactory;
 import weloveclouds.server.models.conf.KVServerPortConstants;
 import weloveclouds.server.models.conf.KVServerPortContext;
-import weloveclouds.server.models.requests.kvclient.IKVClientRequest;
-import weloveclouds.server.models.requests.kvecs.IKVECSRequest;
-import weloveclouds.server.models.requests.kvserver.IKVServerRequest;
 import weloveclouds.server.services.DataAccessServiceFactory;
 import weloveclouds.server.services.IDataAccessService;
 import weloveclouds.server.services.IMovableDataAccessService;
@@ -40,6 +32,8 @@ import weloveclouds.server.utils.LogSetup;
 public class KVServer {
 
     private static final String DEFAULT_LOG_PATH = "logs/server.log";
+    private static final String DEFAULT_LOG_LEVEL = "DEBUG";
+
     private static final Path PERSISTENT_STORAGE_DEFAULT_ROOT_FOLDER = Paths.get("./");
 
     private static final int CLI_KVCLIENT_PORT_INDEX = 0;
@@ -55,6 +49,8 @@ public class KVServer {
      * The entry point of the application.
      */
     public static void main(String[] args) {
+        initializeLoggerWithLevel(DEFAULT_LOG_LEVEL);
+
         if (args.length == 0) {
             startInteractiveCLIMode();
         } else {


### PR DESCRIPTION
* Logger initialization is fixed in KVServer and KVClient. Logger is automatically initialized before the module starts. 
* Default, bootstrap KVServer port is changed in the KVClient to the default KVServerPortConstants.KVCLIENT_REQUESTS_PORT port. 
* fixes #146